### PR TITLE
Added support for installing of the suggested modules.

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -15,7 +15,7 @@
 #
 # This script will re-build everything from scratch every time it runs.
 
-# shellcheck disable=SC2015,SC2094
+# shellcheck disable=SC2015,SC2094,SC2002
 
 set -e
 
@@ -92,6 +92,12 @@ else
   php -d memory_limit=-1 "$(command -v composer)" create-project drupal-composer/drupal-project:9.x-dev "${BUILD_DIR}" --no-interaction
 fi
 
+echo "  > Installing suggested dependencies from module's composer.json."
+composer_suggests=$(cat composer.json | jq -r 'select(.suggest != null) | .suggest | keys[]')
+for composer_suggest in $composer_suggests; do
+  php -d memory_limit=-1 "$(command -v composer)" --working-dir="${BUILD_DIR}" require "${composer_suggest}"
+done
+
 echo "==> Adjusting codebase."
 echo "  > Updating composer.json with a list of allowed plugins."
 cat <<< "$(jq --indent 4 '.config["allow-plugins"]["dealerdirect/phpcodesniffer-composer-installer"] = true' "${BUILD_DIR}/composer.json")" > "${BUILD_DIR}/composer.json"
@@ -136,6 +142,12 @@ ln -s "$(pwd)"/* "${BUILD_DIR}/web/modules/${MODULE}" && rm "${BUILD_DIR}/web/mo
 echo "  > Enabling module ${MODULE}."
 "${BUILD_DIR}/vendor/bin/drush" -r "${BUILD_DIR}/web" pm:enable "${MODULE}" -y
 "${BUILD_DIR}/vendor/bin/drush" -r "${BUILD_DIR}/web" cr
+
+echo "  > Enabling suggested modules, if any."
+drupal_suggests=$(cat composer.json | jq -r 'select(.suggest != null) | .suggest | keys[]' | sed "s/drupal\///" | cut -f1 -d":")
+for drupal_suggest in $drupal_suggests; do
+  "${BUILD_DIR}/vendor/bin/drush" -r "${BUILD_DIR}/web" pm:enable "${drupal_suggest}" -y
+done
 
 # Visit site to pre-warm caches.
 curl -s "http://${WEBSERVER_HOST}:${WEBSERVER_PORT}" > /dev/null

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ committed only to main branches (`9.x-1.x` etc.) to [drupal.org](https://drupal.
 - PHP deprecated code analysis with [Drupal Rector](https://github.com/palantirnet/drupal-rector).
 - Drupal's Simpletest testing support - runs tests in the same way as
   [drupal.org](https://drupal.org)'s Drupal CI bot (`core/scripts/run-tests.sh`).
-- Support for testing recommended dependencies (for integration testing between modules).
+- Support for testing suggested dependencies (for integration testing between modules).
 - Uses [drupal-composer/drupal-project](https://github.com/drupal-composer/drupal-project)
   to provision Drupal site.
 - Mirroring of the repo to [drupal.org](https://drupal.org) (or any other git repo) on release.

--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,8 @@
     ],
     "require-dev": {
         "drupal/pathauto": "~1.0"
+    },
+    "suggest": {
+        "drupal/config_ignore": "Ignore certain configuration during import."
     }
 }


### PR DESCRIPTION
Allows to install packages from `suggest` section in `composer.json` and enable dependencies with `drupal/` prefix (considered as Drupal modules/themes).
```
    "suggest": {
        "drupal/config_ignore": "Ignore certain configuration during import."
    }
```