### PR TITLE
Updated deployment to allow passing a custom destination branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - *deploy_ssh_fingerprint
-      - run: DEPLOY_BRANCH=${CIRCLE_BRANCH} .circleci/deploy.sh
+      - run: DEPLOY_BRANCH=${DEPLOY_BRANCH:-${CIRCLE_BRANCH}} .circleci/deploy.sh
 
 workflows:
   version: 2

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -72,8 +72,12 @@ echo "==> Adding remote ${DEPLOY_REMOTE}."
 git remote add deployremote "${DEPLOY_REMOTE}"
 
 echo "==> Deploying to remote ${DEPLOY_REMOTE}."
-# shellcheck disable=SC2086
-git push --force --tags deployremote ${DEPLOY_BRANCH}
+
+echo "  > Pushing code to branch ${DEPLOY_BRANCH}."
+git push --force deployremote HEAD:"${DEPLOY_BRANCH}"
+
+echo "  > Pushing tags."
+git push --force --tags deployremote || true
 
 echo
 echo "==> Deployment finished."


### PR DESCRIPTION
- Allows to set `DEPLOY_BRANCH` in CI UI and have that propagated to the deployment script.
- Allows to push to a destination `DEPLOY_BRANCH` different than current source branch.
- Separated pushing to the branch and pushing tags
- Allow tags push to fail (as destination may have those already protected)